### PR TITLE
Add settings to store Shelly IPs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".SettingsActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/timingappandroid/MainActivity.java
+++ b/app/src/main/java/com/example/timingappandroid/MainActivity.java
@@ -1,6 +1,8 @@
 
 package com.example.timingappandroid;
 
+import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.View;
@@ -17,6 +19,7 @@ public class MainActivity extends AppCompatActivity {
     private TextView timerTextView;
     private EditText manualTimeInput;
     private Button startPauseButton, minusFiveButton, minusOneButton, plusOneButton, plusFiveButton;
+    private Button settingsButton;
 
     private Handler handler = new Handler();
     private long startTime = 0L;
@@ -61,6 +64,14 @@ public class MainActivity extends AppCompatActivity {
         plusOneButton = findViewById(R.id.plusOneButton);
         plusFiveButton = findViewById(R.id.plusFiveButton);
         manualTimeInput = findViewById(R.id.manualTimeInput);
+        settingsButton = findViewById(R.id.settingsButton);
+
+        settingsButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startActivity(new Intent(MainActivity.this, SettingsActivity.class));
+            }
+        });
 
         startPauseButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -198,21 +209,25 @@ public class MainActivity extends AppCompatActivity {
         new Thread(new Runnable() {
             @Override
             public void run() {
-                try {
-                    // Replace with your Shelly device's IP address
-                    String shellyIp = "192.168.1.200"; 
-                    URL url = new URL("http://" + shellyIp + "/relay/0?turn=on");
-                    HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
-                    urlConnection.disconnect();
+                SharedPreferences prefs = getSharedPreferences("settings", MODE_PRIVATE);
+                String ip1 = prefs.getString("shelly_ip_1", "");
+                String ip2 = prefs.getString("shelly_ip_2", "");
+                String[] ips = {ip1, ip2};
+                for (String shellyIp : ips) {
+                    if (shellyIp == null || shellyIp.isEmpty()) continue;
+                    try {
+                        URL url = new URL("http://" + shellyIp + "/relay/0?turn=on");
+                        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                        conn.disconnect();
 
-                    Thread.sleep(1000);
+                        Thread.sleep(1000);
 
-                    url = new URL("http://" + shellyIp + "/relay/0?turn=off");
-                    urlConnection = (HttpURLConnection) url.openConnection();
-                    urlConnection.disconnect();
-
-                } catch (IOException | InterruptedException e) {
-                    e.printStackTrace();
+                        url = new URL("http://" + shellyIp + "/relay/0?turn=off");
+                        conn = (HttpURLConnection) url.openConnection();
+                        conn.disconnect();
+                    } catch (IOException | InterruptedException e) {
+                        e.printStackTrace();
+                    }
                 }
             }
         }).start();

--- a/app/src/main/java/com/example/timingappandroid/SettingsActivity.java
+++ b/app/src/main/java/com/example/timingappandroid/SettingsActivity.java
@@ -1,0 +1,40 @@
+package com.example.timingappandroid;
+
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class SettingsActivity extends AppCompatActivity {
+    private EditText ip1EditText;
+    private EditText ip2EditText;
+    private Button saveButton;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_settings);
+
+        ip1EditText = findViewById(R.id.ipAddress1EditText);
+        ip2EditText = findViewById(R.id.ipAddress2EditText);
+        saveButton = findViewById(R.id.saveButton);
+
+        SharedPreferences prefs = getSharedPreferences("settings", MODE_PRIVATE);
+        ip1EditText.setText(prefs.getString("shelly_ip_1", ""));
+        ip2EditText.setText(prefs.getString("shelly_ip_2", ""));
+
+        saveButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                prefs.edit()
+                        .putString("shelly_ip_1", ip1EditText.getText().toString().trim())
+                        .putString("shelly_ip_2", ip2EditText.getText().toString().trim())
+                        .apply();
+                finish();
+            }
+        });
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -69,5 +69,12 @@
         android:layout_centerHorizontal="true"
         android:layout_marginBottom="150dp"
         android:text="Start" />
+    <Button
+        android:id="@+id/settingsButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentEnd="true"
+        android:text="@string/settings" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,25 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/ipAddress1EditText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/device_ip_1" />
+
+    <EditText
+        android:id="@+id/ipAddress2EditText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/device_ip_2" />
+
+    <Button
+        android:id="@+id/saveButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/save" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">Timing App</string>
+    <string name="settings">Settings</string>
+    <string name="save">Save</string>
+    <string name="device_ip_1">Device 1 IP</string>
+    <string name="device_ip_2">Device 2 IP</string>
 </resources>


### PR DESCRIPTION
## Summary
- add strings for settings
- add settings screen to save two device IPs
- hook settings screen from main UI
- read saved IPs when flashing Shelly relay

## Testing
- `./gradlew assembleDebug` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686a2c5fbd5083229ff6daaed803c0c0