### PR TITLE
Implement persistent boundary tracking

### DIFF
--- a/app/src/main/java/com/example/timingappandroid/MainActivity.java
+++ b/app/src/main/java/com/example/timingappandroid/MainActivity.java
@@ -28,6 +28,7 @@ public class MainActivity extends AppCompatActivity {
     private boolean isRunning = false;
 
     private final int[] stopTimes = {1800, 3600, 3900, 4200, 4500, 4800}; // 30:00, 60:00, 65:00, 70:00, 75:00, 80:00 in seconds
+    private int nextStopIndex = 0;
 
     private Runnable updateTimerThread = new Runnable() {
         public void run() {
@@ -40,12 +41,10 @@ public class MainActivity extends AppCompatActivity {
 
             timerTextView.setText(String.format("%02d:%02d", mins, secs));
 
-            for (int stopTime : stopTimes) {
-                if (totalSecs >= stopTime) {
-                    pauseTimer();
-                    flashRelay();
-                    break;
-                }
+            if (nextStopIndex < stopTimes.length && totalSecs >= stopTimes[nextStopIndex]) {
+                pauseTimer();
+                flashRelay();
+                nextStopIndex++;
             }
 
             if (isRunning) {
@@ -67,6 +66,8 @@ public class MainActivity extends AppCompatActivity {
         plusFiveButton = findViewById(R.id.plusFiveButton);
         manualTimeInput = findViewById(R.id.manualTimeInput);
         settingsButton = findViewById(R.id.settingsButton);
+
+        updateNextStopIndex(updatedTime);
 
         settingsButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -172,6 +173,8 @@ public class MainActivity extends AppCompatActivity {
         int mins = secs / 60;
         secs = secs % 60;
         timerTextView.setText(String.format("%02d:%02d", mins, secs));
+
+        updateNextStopIndex(updatedTime);
     }
 
     private void updateTimeFromInput(String value) {
@@ -186,6 +189,7 @@ public class MainActivity extends AppCompatActivity {
             int mins = secs / 60;
             secs = secs % 60;
             timerTextView.setText(String.format("%02d:%02d", mins, secs));
+            updateNextStopIndex(updatedTime);
         }
     }
 
@@ -211,6 +215,18 @@ public class MainActivity extends AppCompatActivity {
             }
         }
         return -1;
+    }
+
+    private void updateNextStopIndex(long currentMillis) {
+        int currentSecs = (int) (currentMillis / 1000);
+        int index = stopTimes.length; // default if past last stop
+        for (int i = 0; i < stopTimes.length; i++) {
+            if (currentSecs < stopTimes[i]) {
+                index = i;
+                break;
+            }
+        }
+        nextStopIndex = index;
     }
 
     private void flashRelay() {

--- a/app/src/test/java/com/example/timingappandroid/TimerLogicTest.java
+++ b/app/src/test/java/com/example/timingappandroid/TimerLogicTest.java
@@ -1,0 +1,50 @@
+package com.example.timingappandroid;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class TimerLogicTest {
+    private static class TimerState {
+        private final int[] stopTimes = {1800, 3600, 3900, 4200, 4500, 4800};
+        private int nextStopIndex = 0;
+        void updateNextStopIndex(long currentMillis) {
+            int currentSecs = (int) (currentMillis / 1000);
+            int index = stopTimes.length;
+            for (int i = 0; i < stopTimes.length; i++) {
+                if (currentSecs < stopTimes[i]) {
+                    index = i;
+                    break;
+                }
+            }
+            nextStopIndex = index;
+        }
+        boolean checkForStop(long currentMillis) {
+            int secs = (int) (currentMillis / 1000);
+            if (nextStopIndex < stopTimes.length && secs >= stopTimes[nextStopIndex]) {
+                nextStopIndex++;
+                return true;
+            }
+            return false;
+        }
+        int getNextStopIndex() { return nextStopIndex; }
+    }
+
+    @Test
+    public void testResumePastStopTimes() {
+        TimerState state = new TimerState();
+        assertTrue(state.checkForStop(1_800_000));
+        assertEquals(1, state.getNextStopIndex());
+        assertFalse(state.checkForStop(1_801_000));
+        assertTrue(state.checkForStop(3_600_000));
+        assertEquals(2, state.getNextStopIndex());
+    }
+
+    @Test
+    public void testStartBeyondFirstStop() {
+        TimerState state = new TimerState();
+        state.updateNextStopIndex(1_860_000); // 31:00
+        assertEquals(1, state.getNextStopIndex());
+        assertFalse(state.checkForStop(1_860_000));
+        assertTrue(state.checkForStop(3_600_000));
+    }
+}


### PR DESCRIPTION
## Summary
- track which stop time should be checked next using `nextStopIndex`
- update timer logic to only compare against the upcoming boundary
- recalc the next boundary whenever time is adjusted or manually set
- add simple unit tests demonstrating the boundary logic

## Testing
- `gradle test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a3f91d89c8322ae3a82fd87de12fe