### PR TITLE
Clamp timer adjustments around stop boundaries

### DIFF
--- a/app/src/main/java/com/example/timingappandroid/MainActivity.java
+++ b/app/src/main/java/com/example/timingappandroid/MainActivity.java
@@ -145,17 +145,22 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void adjustTime(long adjustment) {
-        long current = isRunning ? timeSwapBuff + (System.currentTimeMillis() - startTime) : updatedTime;
+        long current = isRunning ?
+                timeSwapBuff + (System.currentTimeMillis() - startTime)
+                : updatedTime;
         long newTime = current + adjustment;
+
+        for (int stopTime : stopTimes) {
+            long boundary = stopTime * 1000L;
+            if (current < boundary && newTime >= boundary) {
+                newTime = boundary;
+            } else if (current > boundary && newTime <= boundary) {
+                newTime = boundary;
+            }
+        }
 
         if (newTime < 0) {
             newTime = 0;
-        }
-
-        for (int stopTime : stopTimes) {
-            if (current < stopTime * 1000 && newTime >= stopTime * 1000) {
-                newTime = stopTime * 1000;
-            }
         }
 
         if (newTime / 1000 > 4800) { // 80:00


### PR DESCRIPTION
## Summary
- enforce clamping logic in `adjustTime` for forward and backward crossings
- add a helper in test suite replicating adjustment logic
- test that +/-1 sec cannot pass automatic stop boundaries

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a41cf0ccc8322a4fad51e35fa5d8e