### PR TITLE
Extend relay activation period

### DIFF
--- a/app/src/main/java/com/example/timingappandroid/MainActivity.java
+++ b/app/src/main/java/com/example/timingappandroid/MainActivity.java
@@ -253,7 +253,8 @@ public class MainActivity extends AppCompatActivity {
                             conn.disconnect();
                         }
 
-                        Thread.sleep(1000);
+                        // Keep the relay on for 5 seconds before turning it off
+                        Thread.sleep(5000);
 
                         url = new URL("http://" + shellyIp + "/relay/0?turn=off");
                         conn = (HttpURLConnection) url.openConnection();


### PR DESCRIPTION
## Summary
- keep external relay on for five seconds when auto-stop triggers

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a4d3b55e48322a613d9cf70572c11