### PR TITLE
Add hidden settings trigger and default IPs

### DIFF
--- a/app/src/main/java/com/example/timingappandroid/MainActivity.java
+++ b/app/src/main/java/com/example/timingappandroid/MainActivity.java
@@ -30,6 +30,9 @@ public class MainActivity extends AppCompatActivity {
     private final int[] stopTimes = {1800, 3600, 3900, 4200, 4500, 4800}; // 30:00, 60:00, 65:00, 70:00, 75:00, 80:00 in seconds
     private int nextStopIndex = 0;
 
+    private int settingsClickCount = 0;
+    private long lastSettingsClickTime = 0L;
+
     private Runnable updateTimerThread = new Runnable() {
         public void run() {
             timeInMilliseconds = System.currentTimeMillis() - startTime;
@@ -72,7 +75,17 @@ public class MainActivity extends AppCompatActivity {
         settingsButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                startActivity(new Intent(MainActivity.this, SettingsActivity.class));
+                long now = System.currentTimeMillis();
+                if (now - lastSettingsClickTime < 600) {
+                    settingsClickCount++;
+                } else {
+                    settingsClickCount = 1;
+                }
+                lastSettingsClickTime = now;
+                if (settingsClickCount >= 5) {
+                    settingsClickCount = 0;
+                    startActivity(new Intent(MainActivity.this, SettingsActivity.class));
+                }
             }
         });
 
@@ -239,8 +252,8 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void run() {
                 SharedPreferences prefs = getSharedPreferences("settings", MODE_PRIVATE);
-                String ip1 = prefs.getString("shelly_ip_1", "");
-                String ip2 = prefs.getString("shelly_ip_2", "");
+                String ip1 = prefs.getString("shelly_ip_1", "192.168.1.200");
+                String ip2 = prefs.getString("shelly_ip_2", "192.168.1.201");
                 String[] ips = {ip1, ip2};
                 for (String shellyIp : ips) {
                     if (shellyIp == null || shellyIp.isEmpty()) continue;

--- a/app/src/main/java/com/example/timingappandroid/SettingsActivity.java
+++ b/app/src/main/java/com/example/timingappandroid/SettingsActivity.java
@@ -23,8 +23,8 @@ public class SettingsActivity extends AppCompatActivity {
         saveButton = findViewById(R.id.saveButton);
 
         SharedPreferences prefs = getSharedPreferences("settings", MODE_PRIVATE);
-        ip1EditText.setText(prefs.getString("shelly_ip_1", ""));
-        ip2EditText.setText(prefs.getString("shelly_ip_2", ""));
+        ip1EditText.setText(prefs.getString("shelly_ip_1", "192.168.1.200"));
+        ip2EditText.setText(prefs.getString("shelly_ip_2", "192.168.1.201"));
 
         saveButton.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -77,6 +77,8 @@
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:layout_alignParentEnd="true"
-        android:text="@string/settings" />
+        android:text="@string/settings"
+        android:alpha="0"
+        android:background="@android:color/transparent" />
 
 </RelativeLayout>


### PR DESCRIPTION
## Summary
- hide the Settings button by making it transparent
- open settings after 5 rapid taps in the hidden area
- default the Shelly IP addresses to `192.168.1.200` and `192.168.1.201`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a4e29f27483228b665fca018ff25c