### PR TITLE
Fix cleartext HTTP requests

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
         android:label="@string/app_name"
         android:roundIcon="@android:drawable/sym_def_app_icon"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
## Summary
- allow cleartext HTTP traffic in the manifest for the Shelly relay

## Testing
- `gradlew test` *(fails: could not run Gradle due to missing sdk)*

------
https://chatgpt.com/codex/tasks/task_e_686a51bd1ef48322b98278fda770f722