### PR TITLE
Reduce relay timeout for faster LED response

### DIFF
--- a/app/src/main/java/com/example/timingappandroid/MainActivity.java
+++ b/app/src/main/java/com/example/timingappandroid/MainActivity.java
@@ -260,6 +260,8 @@ public class MainActivity extends AppCompatActivity {
                     try {
                         URL url = new URL("http://" + shellyIp + "/color/0?turn=on&red=255&green=0&blue=0");
                         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                        conn.setConnectTimeout(1000);
+                        conn.setReadTimeout(1000);
                         try {
                             conn.getResponseCode();
                         } finally {
@@ -271,6 +273,8 @@ public class MainActivity extends AppCompatActivity {
 
                         url = new URL("http://" + shellyIp + "/color/0?turn=off");
                         conn = (HttpURLConnection) url.openConnection();
+                        conn.setConnectTimeout(1000);
+                        conn.setReadTimeout(1000);
                         try {
                             conn.getResponseCode();
                         } finally {


### PR DESCRIPTION
## Summary
- set HTTP connection timeouts to 1s when triggering the Shelly relay

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686a64f474a08322942702b65c7f5c9b