### PR TITLE
Reduce delay by activating relays in parallel

### DIFF
--- a/app/src/main/java/com/example/timingappandroid/MainActivity.java
+++ b/app/src/main/java/com/example/timingappandroid/MainActivity.java
@@ -255,22 +255,14 @@ public class MainActivity extends AppCompatActivity {
                 String ip1 = prefs.getString("shelly_ip_1", "192.168.1.200");
                 String ip2 = prefs.getString("shelly_ip_2", "192.168.1.201");
                 String[] ips = {ip1, ip2};
+                // Trigger all relays on first
                 for (String shellyIp : ips) {
                     if (shellyIp == null || shellyIp.isEmpty()) continue;
                     try {
                         URL url = new URL("http://" + shellyIp + "/color/0?turn=on&red=255&green=0&blue=0");
                         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-                        try {
-                            conn.getResponseCode();
-                        } finally {
-                            conn.disconnect();
-                        }
-
-                        // Keep the relay on for 5 seconds before turning it off
-                        Thread.sleep(5000);
-
-                        url = new URL("http://" + shellyIp + "/color/0?turn=off");
-                        conn = (HttpURLConnection) url.openConnection();
+                        conn.setConnectTimeout(1000);
+                        conn.setReadTimeout(1000);
                         try {
                             conn.getResponseCode();
                         } finally {
@@ -278,8 +270,31 @@ public class MainActivity extends AppCompatActivity {
                         }
                     } catch (IOException e) {
                         e.printStackTrace();
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
+                    }
+                }
+
+                // Keep the relays on for 5 seconds before turning them off
+                try {
+                    Thread.sleep(5000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+
+                // Now turn all relays off
+                for (String shellyIp : ips) {
+                    if (shellyIp == null || shellyIp.isEmpty()) continue;
+                    try {
+                        URL url = new URL("http://" + shellyIp + "/color/0?turn=off");
+                        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                        conn.setConnectTimeout(1000);
+                        conn.setReadTimeout(1000);
+                        try {
+                            conn.getResponseCode();
+                        } finally {
+                            conn.disconnect();
+                        }
+                    } catch (IOException e) {
+                        e.printStackTrace();
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- send LED ON commands to all configured Shelly IPs first
- wait 5s once, then send all OFF commands

This avoids a serial 5‑second wait per device which caused one side's LED to light much later than the other.

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_686a64f474a08322942702b65c7f5c9b